### PR TITLE
Made user reviews dependent destroy

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
 
-  has_many :reviews
+  has_many :reviews, :dependent => :delete_all
   has_many :green_spaces, through: :reviews
   has_many :votes
 


### PR DESCRIPTION
Reviews now have a dependent destroy relationship with their users to avoid invalid data if a user account is deleted. The troublesome review on heroku has been deleted and this patch will prevent it from happening again.